### PR TITLE
Adding CTM configuration file

### DIFF
--- a/ctm.yaml
+++ b/ctm.yaml
@@ -1,0 +1,3 @@
+ctm:
+  - type: artifactory-maven
+    output: ~/.m2/settings.xml


### PR DESCRIPTION
Circle Token Manager now has a way to get ephemeral tokens that last
only an hour from the time a build is triggered. This configures the
init script to grab a settings file with credentials to artifactory.

@infusionsoft/sre @frossbeamish Please take a look.